### PR TITLE
feat: add support for react 18 type update

### DIFF
--- a/src/components/KeepAlive.tsx
+++ b/src/components/KeepAlive.tsx
@@ -4,12 +4,12 @@ import {START_MOUNTING_DOM, LIFECYCLE} from './Provider';
 import keepAlive, {COMMAND} from '../utils/keepAliveDecorator';
 import changePositionByComment from '../utils/changePositionByComment';
 
-interface IKeepAliveProps {
+type IKeepAliveProps = React.PropsWithChildren<{
   key?: string;
   name?: string;
   disabled?: boolean;
   extra?: any;
-}
+}>
 
 interface IKeepAliveInnerProps extends IKeepAliveProps {
   _container: any;

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -47,7 +47,7 @@ export interface IKeepAliveProviderProps {
   max?: number;
 }
 
-export default class KeepAliveProvider extends React.PureComponent<IKeepAliveProviderProps> implements IKeepAliveProviderImpl {
+export default class KeepAliveProvider extends React.PureComponent<React.PropsWithChildren<IKeepAliveProviderProps>> implements IKeepAliveProviderImpl {
   public static displayName = keepAliveProviderTypeName;
 
   public static defaultProps = {


### PR DESCRIPTION
in react 18, component props type will remove default children declare so we need declare it by self

or it will throw error like this:
![image](https://user-images.githubusercontent.com/6964737/208091157-fdcfd4fb-a1f1-4044-9d57-4e27c2170374.png)
